### PR TITLE
fix multiple error events for single onError value

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -151,9 +151,9 @@ tryCache = function(tmpDir) {
   });
 };
 
-activeLoader = function(meta, loader, tmpDir, onError) {
+activeLoader = function(meta, loader, tmpDir) {
   var cachedData, data, fromCache, insurance, rawData;
-  rawData = meta.flatMapLatest(loader).tapOnError(onError);
+  rawData = meta.flatMapLatest(loader);
   insurance = crashRecovery(tmpDir);
   data = rawData.tap(insurance.onDataLoaded).publish();
   fromCache = tryCache(tmpDir);
@@ -163,19 +163,19 @@ activeLoader = function(meta, loader, tmpDir, onError) {
   return cachedData;
 };
 
-passiveLoader = function(tmpDir, onError) {
+passiveLoader = function(tmpDir) {
   var data, rawData;
   rawData = latestCacheFile(tmpDir, true);
-  data = rawData.tapOnError(onError).publish();
+  data = rawData.publish();
   data.connect();
   return data;
 };
 
-this.cachedLoader = function(meta, loader, tmpDir, active, onError) {
+this.cachedLoader = function(meta, loader, tmpDir, active) {
   debug('cachedLoader(%j)', active);
   if (active) {
-    return activeLoader(meta, loader, tmpDir, onError);
+    return activeLoader(meta, loader, tmpDir);
   } else {
-    return passiveLoader(tmpDir, onError);
+    return passiveLoader(tmpDir);
   }
 };

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -77,7 +77,7 @@ SharedStore = (function(_super) {
     })(this));
     this.stream = cachedLoader(meta, loader, temp, active, this.emit.bind(this, 'error'));
     this._receivedData = false;
-    this._subscription = this.stream.subscribe(this._handleUpdate, this._handleError);
+    this.stream.subscribe(this._handleUpdate, this._handleError);
     this._cache = null;
   }
 

--- a/src/cache.coffee
+++ b/src/cache.coffee
@@ -105,10 +105,8 @@ tryCache = (tmpDir) ->
       else
         Observable.throw error
 
-activeLoader = (meta, loader, tmpDir, onError) ->
-  rawData = meta
-    .flatMapLatest(loader)
-    .tapOnError(onError)
+activeLoader = (meta, loader, tmpDir) ->
+  rawData = meta.flatMapLatest(loader)
 
   insurance = crashRecovery tmpDir
 
@@ -128,14 +126,14 @@ activeLoader = (meta, loader, tmpDir, onError) ->
 
   return cachedData
 
-passiveLoader = (tmpDir, onError) ->
+passiveLoader = (tmpDir) ->
   rawData = latestCacheFile(tmpDir, true)
 
-  data = rawData.tapOnError(onError).publish()
+  data = rawData.publish()
   data.connect()
   return data
 
-@cachedLoader = (meta, loader, tmpDir, active, onError) ->
+@cachedLoader = (meta, loader, tmpDir, active) ->
   debug 'cachedLoader(%j)', active
-  if active then activeLoader(meta, loader, tmpDir, onError)
-  else passiveLoader(tmpDir, onError)
+  if active then activeLoader(meta, loader, tmpDir)
+  else passiveLoader(tmpDir)

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -59,7 +59,7 @@ class SharedStore extends EventEmitter
     )
 
     @_receivedData = false
-    @_subscription = @stream.subscribe @_handleUpdate, @_handleError
+    @stream.subscribe @_handleUpdate, @_handleError
 
     @_cache = null
 

--- a/test/shared-store.test.coffee
+++ b/test/shared-store.test.coffee
@@ -115,6 +115,6 @@ describe 'SharedStore', ->
         assert.deepEqual {}, data
         assert.equal null, err
 
-      store.once 'error', (err) ->
+      store.on 'error', (err) ->
         assert.equal '¡Ay, caramba!', err.message
         done()


### PR DESCRIPTION
Found a bug where two error events will be triggered for a single onError produced by an observable.  This PR should rectify it.