### PR TITLE
fix fetching data from cache with init

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Creates a new store, based on the given `loader`.
 Sets the options that will be passed into the loader.
 The promise will be resolved with the initial data.
 
+Note that cached data could be returned in the callback/promise if it already
+exists.
+
 `SharedStore` does not interpret `options` in any way,
 it is just forwarded to the loader.
 

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -98,6 +98,11 @@ SharedStore = (function(_super) {
     }
     result = new Promise((function(_this) {
       return function(resolve, reject) {
+        var current;
+        current = _this.getCurrent();
+        if (current != null) {
+          return resolve(current);
+        }
         return _this.stream.take(1).map(property('data')).subscribe(resolve, reject);
       };
     })(this));

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -75,6 +75,9 @@ class SharedStore extends EventEmitter
       options = {}
 
     result = new Promise (resolve, reject) =>
+      current = @getCurrent()
+      return resolve(current) if current?
+
       @stream.take(1)
         .map property 'data'
         .subscribe resolve, reject

--- a/test/shared-store.test.coffee
+++ b/test/shared-store.test.coffee
@@ -118,3 +118,25 @@ describe 'SharedStore', ->
       store.on 'error', (err) ->
         assert.equal '¡Ay, caramba!', err.message
         done()
+
+  describe 'with data already in cache', ->
+    before (done) ->
+      tmp.dir { unsafeCleanup: true }, (err, @cacheTmpDir) =>
+        store = new SharedStore
+          temp: @cacheTmpDir
+          loader: Observable.just {data: 'some data'}
+        store.init (err) ->
+          done()
+
+    it 'will return cached data in init callback if it already exists', (done) ->
+      store = new SharedStore
+        temp: @cacheTmpDir
+        loader: Observable
+          .just {data: 'other data'}
+          .delay 5000
+
+      setTimeout ->
+        store.init (err, current) ->
+          assert.equal 'some data', current
+          done()
+      , 1000


### PR DESCRIPTION
Discovered another issue where if init() is only executed a long time after it's constructed, the callback will never be called.

The reason for this is the init callback calls .take(1) on the hot observable, and the hot observable has a cached value that is the same as the loaded value.  When combined with distinctUntilChanged, the hot observable won't return anything on the init callback as the constructor will generally produce the cached data immediately.