### PR TITLE
fix getaddrinfo ENOTFOUND

### DIFF
--- a/lib/dir-content.js
+++ b/lib/dir-content.js
@@ -130,7 +130,7 @@ dirContent = function(dir, _arg) {
       }
     });
   };
-  initial = fromPromiseFunction(statDir).flatMap(Observable.fromArray);
+  initial = fromPromiseFunction(statDir).flatMap(Observable.from);
   if (watch) {
     return initial.concat(dirChanges(dir, {
       statFiles: statFiles

--- a/lib/http.js
+++ b/lib/http.js
@@ -45,7 +45,7 @@ fromPromiseFunction = require('./promise').fromPromiseFunction;
 onInterval = require('./interval');
 
 httpResource = function(_arg) {
-  var checkModified, fetch, interval, lastBody, lastETag, lastModified, load, returnLastKnown, wrap;
+  var checkModified, fetch, interval, lastBody, lastETag, lastModified, load, wrap;
   fetch = _arg.fetch, interval = _arg.interval;
   lastETag = void 0;
   lastModified = void 0;
@@ -74,19 +74,11 @@ httpResource = function(_arg) {
     }
     return lastBody;
   };
-  returnLastKnown = function(error) {
-    if (lastBody != null) {
-      debug('Failed, return last known', error);
-      return lastBody;
-    } else {
-      return Promise.reject(error);
-    }
-  };
   load = partial(fromPromiseFunction, function() {
     return fetch({
       'If-None-Match': lastETag,
       'If-Modified-Since': lastModified
-    }).then(checkModified, returnLastKnown);
+    }).then(checkModified);
   });
   return onInterval(interval, load);
 };

--- a/src/dir-content.coffee
+++ b/src/dir-content.coffee
@@ -98,7 +98,7 @@ dirContent = (dir, {watch, statFiles} = {}) ->
         props
 
   initial = fromPromiseFunction(statDir)
-    .flatMap(Observable.fromArray)
+    .flatMap(Observable.from)
 
   if watch
     initial.concat dirChanges(dir, {statFiles})

--- a/src/http.coffee
+++ b/src/http.coffee
@@ -60,17 +60,11 @@ httpResource = ({fetch, interval}) ->
 
     lastBody
 
-  returnLastKnown = (error) ->
-    if lastBody?
-      debug 'Failed, return last known', error
-      lastBody
-    else Promise.reject error
-
   load = partial fromPromiseFunction, ->
     fetch({
       'If-None-Match': lastETag
       'If-Modified-Since': lastModified
-    }).then(checkModified, returnLastKnown)
+    }).then(checkModified)
 
   onInterval interval, load
 


### PR DESCRIPTION
There's a non-deterministic error where if the hostname can't even resolve for a fetch operation, the promise might throw instead of being caught.

I've been digging around trying to work out root cause, but I haven't been able to.

In lieu of this, the initial http rejection isn't really needed since it'll bubble up and return the last valid cache anyhow.