### PR TITLE
Fix ENOTFOUND error

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -153,35 +153,28 @@ tryCache = function(tmpDir) {
 };
 
 activeLoader = function(meta, loader, tmpDir) {
-  var cachedData, data, fromCache, onDataLoaded, rawData, tearDownCrashHandler, _ref1;
+  var data, fromCache, onDataLoaded, rawData, tearDownCrashHandler, _ref1;
   rawData = meta.flatMapLatest(loader).map(function(data) {
     data.usingCache = false;
     return data;
   });
   _ref1 = crashRecovery(tmpDir), onDataLoaded = _ref1.onDataLoaded, tearDownCrashHandler = _ref1.tearDownCrashHandler;
-  data = rawData.tap(onDataLoaded, tearDownCrashHandler, tearDownCrashHandler).publish();
+  data = rawData.tap(onDataLoaded, tearDownCrashHandler, tearDownCrashHandler);
   fromCache = tryCache(tmpDir);
-  cachedData = fromCache.takeUntil(data).merge(data).distinctUntilChanged(property('data'), isEqual).flatMapLatest(partial(writeCache, tmpDir)).publish();
-  cachedData.connectAll = function() {
-    data.connect();
-    return cachedData.connect();
-  };
-  return cachedData;
+  return fromCache.takeUntil(data).merge(data).distinctUntilChanged(property('data'), isEqual).flatMapLatest(partial(writeCache, tmpDir)).publish();
 };
 
 passiveLoader = function(tmpDir) {
-  var data, rawData;
-  rawData = latestCacheFile(tmpDir, true);
-  data = rawData.publish();
-  data.connectAll = data.connect;
-  return data;
+  return latestCacheFile(tmpDir, true).publish();
 };
 
 this.cachedLoader = function(meta, loader, tmpDir, active) {
   debug('cachedLoader(%j)', active);
-  if (active) {
-    return activeLoader(meta, loader, tmpDir);
-  } else {
-    return passiveLoader(tmpDir);
-  }
+  loader = active ? activeLoader(meta, loader, tmpDir) : passiveLoader(tmpDir);
+  return Observable.create(function(observer) {
+    loader.subscribe(observer);
+    loader.connect();
+  });
 };
+
+this.latestCacheFile = latestCacheFile;

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -32,7 +32,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var EventEmitter, Observable, Promise, RETRY_MULTIPLIER, SharedStore, TEN_MINUTES, TEN_SECONDS, cachedLoader, cluster, freeze, path, property, safeMerge,
+var EventEmitter, Observable, Promise, RETRY_MULTIPLIER, SharedStore, TEN_MINUTES, TEN_SECONDS, cachedLoader, cluster, freeze, latestCacheFile, path, property, safeMerge, _ref,
   __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
   __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
   __hasProp = {}.hasOwnProperty;
@@ -51,7 +51,7 @@ freeze = require('deep-freeze');
 
 property = require('lodash').property;
 
-cachedLoader = require('./cache').cachedLoader;
+_ref = require('./cache'), cachedLoader = _ref.cachedLoader, latestCacheFile = _ref.latestCacheFile;
 
 safeMerge = require('./safe-merge');
 
@@ -75,17 +75,16 @@ SharedStore = (function(_super) {
     if (active == null) {
       active = cluster.isMaster;
     }
-    temp = path.resolve(temp);
+    this._temp = path.resolve(temp);
     this._createStream = (function(_this) {
       return function() {
-        var meta, _ref;
-        if ((_ref = _this.subscription) != null) {
-          _ref.dispose();
+        var meta, _ref1;
+        if ((_ref1 = _this.subscription) != null) {
+          _ref1.dispose();
         }
         meta = _this._createMeta();
-        _this.stream = cachedLoader(meta, loader, temp, active);
-        _this.subscription = _this.stream.subscribe(_this._handleUpdate, _this._handleError);
-        return _this.stream.connectAll();
+        _this.stream = cachedLoader(meta, loader, _this._temp, active);
+        return _this.subscription = _this.stream.subscribe(_this._handleUpdate, _this._handleError);
       };
     })(this);
     this._createStream();
@@ -95,8 +94,8 @@ SharedStore = (function(_super) {
   }
 
   SharedStore.prototype.getCurrent = function() {
-    var _ref;
-    return (_ref = this._cache) != null ? _ref.data : void 0;
+    var _ref1;
+    return (_ref1 = this._cache) != null ? _ref1.data : void 0;
   };
 
   SharedStore.prototype.getCurrentWithMetaData = function() {
@@ -111,12 +110,17 @@ SharedStore = (function(_super) {
     }
     result = new Promise((function(_this) {
       return function(resolve, reject) {
-        var current;
+        var current, originalErr;
         current = _this.getCurrent();
         if (current != null) {
           return resolve(current);
         }
-        return _this.stream.take(1).map(property('data')).subscribe(resolve, reject);
+        originalErr = null;
+        return _this.stream.take(1).map(property('data')).tapOnError(function(err) {
+          return originalErr = err;
+        })["catch"](latestCacheFile(_this._temp)).subscribe(resolve, function(err) {
+          return reject(originalErr);
+        });
       };
     })(this));
     this.emit('meta', options);
@@ -141,7 +145,7 @@ SharedStore = (function(_super) {
   };
 
   SharedStore.prototype._handleUpdate = function(_arg) {
-    var data, source, time, usingCache, _ref;
+    var data, source, time, usingCache, _ref1;
     data = _arg.data, time = _arg.time, source = _arg.source, usingCache = _arg.usingCache;
     if (usingCache === false) {
       this._retryTimeout = TEN_SECONDS;
@@ -153,15 +157,15 @@ SharedStore = (function(_super) {
     });
     this.emit('changed', {
       isWorker: cluster.isWorker,
-      id: (_ref = cluster.worker) != null ? _ref.id : void 0
+      id: (_ref1 = cluster.worker) != null ? _ref1.id : void 0
     });
     return this.emit('data', this._cache.data);
   };
 
   SharedStore.prototype._handleMetaUpdate = function(_at__options) {
-    var _ref;
+    var _ref1;
     this._options = _at__options;
-    return (_ref = this._metaObserver) != null ? _ref.onNext(this._options) : void 0;
+    return (_ref1 = this._metaObserver) != null ? _ref1.onNext(this._options) : void 0;
   };
 
   SharedStore.prototype._retry = function() {

--- a/src/interval.coffee
+++ b/src/interval.coffee
@@ -37,9 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 onInterval = (interval, load) ->
   if interval > 0
     if interval < 1000
-      Observable.throw new Error """
-        Interval has to be at least 1s: #{interval}ms
-      """
+      Observable.throw new Error "Interval has to be at least 1s: #{interval}ms"
     else
       load().concat(
         Observable.interval(interval).flatMap(load)


### PR DESCRIPTION
See #15 and #17 for more context.

When using the HTTP loader, ENOTFOUND never gives the cache a chance to return anything and returns immediately, propagating all the way to `store.init`'s stream.  The promise is then rejected, which crashes the app without even checking whether a cache file exists.

This PR also removes a redundant `publish()` in `cache.coffee` along with some cleanup.