### PR TITLE
Fix null getCurrent when store.init errors & fetches from cache

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -116,9 +116,18 @@ SharedStore = (function(_super) {
           return resolve(current);
         }
         originalErr = null;
-        return _this.stream.take(1).map(property('data')).tapOnError(function(err) {
+        return _this.stream.take(1).tapOnError(function(err) {
           return originalErr = err;
-        })["catch"](latestCacheFile(_this._temp)).subscribe(resolve, function(err) {
+        })["catch"](latestCacheFile(_this._temp)).subscribe(function(_arg) {
+          var data, source, time;
+          data = _arg.data, time = _arg.time, source = _arg.source;
+          _this._cache = freeze({
+            data: data,
+            time: time,
+            source: source
+          });
+          return resolve(data);
+        }, function(err) {
           return reject(originalErr);
         });
       };

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -110,26 +110,22 @@ SharedStore = (function(_super) {
     }
     result = new Promise((function(_this) {
       return function(resolve, reject) {
-        var current, originalErr;
-        current = _this.getCurrent();
-        if (current != null) {
-          return resolve(current);
-        }
-        originalErr = null;
-        return _this.stream.take(1).tapOnError(function(err) {
-          return originalErr = err;
-        })["catch"](latestCacheFile(_this._temp)).subscribe(function(_arg) {
-          var data, source, time;
-          data = _arg.data, time = _arg.time, source = _arg.source;
-          _this._cache = freeze({
-            data: data,
-            time: time,
-            source: source
-          });
+        var handleData, handleErr;
+        handleData = function(data) {
+          _this.removeListener('err', handleErr);
           return resolve(data);
-        }, function(err) {
-          return reject(originalErr);
-        });
+        };
+        handleErr = function(err) {
+          _this.removeListener('data', handleData);
+          return latestCacheFile(_this._temp).subscribe(function(cache) {
+            _this._handleUpdate(cache);
+            return resolve(cache.data);
+          }, function() {
+            return reject(err);
+          });
+        };
+        _this.once('data', handleData);
+        return _this.once('err', handleErr);
       };
     })(this));
     this.emit('meta', options);

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -83,11 +83,15 @@ class SharedStore extends EventEmitter
 
       originalErr = null
       @stream.take(1)
-        .map property 'data'
         .tapOnError (err) -> originalErr = err
         .catch latestCacheFile @_temp
-        .subscribe resolve, (err) ->
-          reject originalErr
+        .subscribe(
+          ({ data, time, source }) =>
+            @_cache = freeze { data, time, source }
+            resolve data
+          (err) ->
+            reject originalErr
+        )
 
     @emit 'meta', options
 

--- a/test/shared-store/error-handling.test.coffee
+++ b/test/shared-store/error-handling.test.coffee
@@ -7,30 +7,66 @@ tmp = require 'tmp'
 SharedStore = require '../../'
 
 describe 'SharedStore (error handling)', ->
-  before (done) ->
-    tmp.dir { unsafeCleanup: true }, (err, @tmpDir) => done(err)
-
   describe 'reading from a loader that throws an error immediately', ->
-    it 'will return the error through callback', (done) ->
-      thrownError = false
-      store = new SharedStore
-        temp: @tmpDir
-        loader: Observable.create (observer) ->
-          return if thrownError
-          observer.onError new Error 'This throws!'
-          thrownError = true
+    describe 'with no cache', ->
+      tmpDir = null
+      before (done) ->
+        tmp.dir { unsafeCleanup: true }, (err, tmpDirParam) ->
+          tmpDir = tmpDirParam
+          done(err)
 
-      store.init (err, data) ->
-        assert.hasType undefined, data
-        assert.hasType undefined, store.getCurrent()
-        assert.equal 'This throws!', err.message
-        done()
+      it 'will return the error through callback', (done) ->
+        thrownError = false
+        store = new SharedStore
+          temp: tmpDir
+          loader: Observable.create (observer) ->
+            return if thrownError
+            observer.onError new Error 'This throws!'
+            thrownError = true
+
+        store.init (err, data) ->
+          assert.hasType undefined, data
+          assert.hasType undefined, store.getCurrent()
+          assert.equal 'This throws!', err.message
+          done()
+
+    describe 'with a cache', ->
+      tmpDir = null
+      before (done) ->
+        tmp.dir { unsafeCleanup: true }, (err, tmpDirParam) ->
+          tmpDir = tmpDirParam
+          store = new SharedStore
+            temp: tmpDir
+            loader: -> Observable.just {data: 'tastic'}
+          store.init (err, data) ->
+            done(err)
+
+      it 'will return the cache through callback & getCurrent', (done) ->
+        thrownError = false
+        store = new SharedStore
+          temp: tmpDir
+          loader: Observable.create (observer) ->
+            return if thrownError
+            observer.onError new Error 'This throws!'
+            thrownError = true
+
+        store.init (err, data) ->
+          assert.equal 'tastic', data
+          assert.equal 'tastic', store.getCurrent()
+          assert.equal null, err
+          done()
 
   describe 'reading from a loader that throws an error after a successful read', ->
+    tmpDir = null
+    before (done) ->
+      tmp.dir { unsafeCleanup: true }, (err, tmpDirParam) ->
+        tmpDir = tmpDirParam
+        done(err)
+
     it 'will return the error through event handler', (done) ->
       thrownError = false
       store = new SharedStore
-        temp: @tmpDir
+        temp: tmpDir
         loader: Observable.create (observer) ->
           observer.onNext {data: {}}
           setTimeout ->


### PR DESCRIPTION
When `store.init` errors & another piece of code uses `store.getCurrent`, `@_cache` isn't populated so null is returned.  This code fixes that!