### PR TITLE
emit correct @_options to meta

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -175,7 +175,7 @@ SharedStore = (function(_super) {
 
   SharedStore.prototype._retry = function() {
     this._createStream();
-    this.emit('meta', this.options);
+    this.emit('meta', this._options);
     this._retryTimeout *= RETRY_MULTIPLIER;
     if (this._retryTimeout > TEN_MINUTES) {
       return this._retryTimeout = TEN_MINUTES;

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -124,7 +124,7 @@ class SharedStore extends EventEmitter
 
   _retry: =>
     @_createStream()
-    @emit 'meta', @options
+    @emit 'meta', @_options
     @_retryTimeout *= RETRY_MULTIPLIER
     @_retryTimeout = TEN_MINUTES if @_retryTimeout > TEN_MINUTES
 

--- a/test/shared-store/retry.test.coffee
+++ b/test/shared-store/retry.test.coffee
@@ -1,0 +1,30 @@
+'use strict'
+
+assert = require 'assertive'
+{Observable} = require 'rx'
+tmp = require 'tmp'
+
+SharedStore = require '../../'
+
+describe 'SharedStore (retry functionality)', ->
+  before (done) ->
+    tmp.dir { unsafeCleanup: true }, (err, @tmpDir) => done(err)
+
+  describe 'reading from a loader with a single value', ->
+    store = null
+    before ->
+      store = new SharedStore
+        temp: @tmpDir
+        loader: Observable.just {data: 'test'}
+
+    it 'init and retry will emit the same meta ', (done) ->
+      metaCount = 0
+      store.on 'meta', (options) ->
+        assert.equal 'some-options', options
+        metaCount++
+
+      store.init 'some-options'
+      store._retry()
+
+      assert.equal 2, metaCount
+      done()


### PR DESCRIPTION
During retry, this emits `@options`, which doesn't exist.  We should be emitting `@_options` instead.