### PR TITLE
fix to resolve store.init if cache = loaded data

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -111,6 +111,9 @@ SharedStore = (function(_super) {
     result = new Promise((function(_this) {
       return function(resolve, reject) {
         var handleData, handleErr;
+        if (_this._cache != null) {
+          return resolve(_this._cache.data);
+        }
         handleData = function(data) {
           _this.removeListener('err', handleErr);
           return resolve(data);

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -78,6 +78,8 @@ class SharedStore extends EventEmitter
       options = {}
 
     result = new Promise (resolve, reject) =>
+      return resolve @_cache.data if @_cache?
+
       handleData = (data) =>
         @removeListener 'err', handleErr
         resolve data

--- a/test/shared-store/with-cache.test.coffee
+++ b/test/shared-store/with-cache.test.coffee
@@ -42,6 +42,22 @@ describe 'SharedStore (with data already in cache)', ->
     it 'should return latest data in getCurrent', ->
       assert.equal 'other data', store.getCurrent()
 
+  describe 'having cache data = loaded data', ->
+    store = null
+
+    beforeEach ->
+      store = new SharedStore
+        temp: cacheTmpDir
+        loader: Observable.just {data: 'some data'}
+
+    it "should resolve the promise even if there's a long period between construction & initialization", ->
+      Promise
+        .delay 1000
+        .then ->
+          store.init()
+        .then (data) ->
+          assert.equal 'some data', data
+
   describe 'throwing a load error & then producing a value', ->
     store = thrownError = null
 


### PR DESCRIPTION
If a cache already exists & the shared-store constructor is called, the stream will return the cache first & trigger the `handleUpdate` event.

When `store.init` is called, it'll emit the `meta` event to load the data.  If the loaded data is the same as the cached data, then the stream won't produce a value and the `handleUpdate` event won't be triggered.

This will cause `store.init`'s promise to hang because neither the handleUpdate nor the handleErr event will ever be triggered.

This occurs in a situation where:

1. A cache exists.
2. The cache is the same as the loaded data.
3. `store.init` is called long after store is constructed (or to put more precisely, the cache produces a value for the stream before the loader takes over).