### PR TITLE
make JSON parsing throw if it fails

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -32,7 +32,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var CSON, Promise, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, isMissingError, onInterval, parserFromExtension, partial, path, promisify, readFile, _ref;
+var CSON, Promise, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, onInterval, parserFromExtension, partial, path, promisify, readFileAsync, _ref;
 
 fs = require('fs');
 
@@ -52,7 +52,7 @@ onInterval = require('./interval');
 
 dirChanges = require('./dir-content').dirChanges;
 
-readFile = promisify(fs.readFile);
+readFileAsync = promisify(fs.readFile);
 
 fileChanges = function(filename, options) {
   return dirChanges(path.dirname(filename), options).filter(function(_arg) {
@@ -60,10 +60,6 @@ fileChanges = function(filename, options) {
     absolute = _arg.absolute;
     return absolute === filename;
   });
-};
-
-isMissingError = function(error) {
-  return error.cause && error.cause.code === 'ENOENT';
 };
 
 parserFromExtension = function(filename) {
@@ -109,8 +105,8 @@ fileContent = function(filename, options) {
     };
   };
   load = partial(fromPromiseFunction, function() {
-    debug('readFile %s', filename);
-    return readFile(filename, 'utf8').tap(loaded).then(parse).then(wrap)["catch"](isMissingError, returnDefault);
+    debug('readFileAsync %s', filename);
+    return readFileAsync(filename, 'utf8').tap(loaded).then(parse).then(wrap)["catch"](returnDefault);
   });
   if (watch) {
     return load().concat(fileChanges(filename).flatMap(load));

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -44,14 +44,11 @@ debug = require('debug') 'shared-store:file'
 onInterval = require './interval'
 {dirChanges} = require './dir-content'
 
-readFile = promisify fs.readFile
+readFileAsync = promisify fs.readFile
 
 fileChanges = (filename, options) ->
   dirChanges(path.dirname(filename), options)
     .filter ({absolute}) -> absolute == filename
-
-isMissingError = (error) ->
-  error.cause && error.cause.code == 'ENOENT'
 
 parserFromExtension = (filename) ->
   switch path.extname filename
@@ -77,12 +74,12 @@ fileContent = (filename, options = {}) ->
     { data, time: Date.now(), source: filename }
 
   load = partial fromPromiseFunction, ->
-    debug 'readFile %s', filename
-    readFile(filename, 'utf8')
+    debug 'readFileAsync %s', filename
+    readFileAsync(filename, 'utf8')
       .tap loaded
       .then parse
       .then wrap
-      .catch isMissingError, returnDefault
+      .catch returnDefault
 
   if watch
     load().concat fileChanges(filename).flatMap(load)


### PR DESCRIPTION
Can't remember why we swallowed up all the errors here aside from ENOENT (see `isMissingError`), but failed JSON parsing was getting swallowed up as well.

If you can't think of the reason why, then perhaps we should be throwing on all errors.