### PR TITLE
More useful parse errors for files

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -32,7 +32,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var CSON, Promise, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, isMissingError, onInterval, parserFromExtension, partial, path, promisify, readFile, _ref;
+var CSON, Promise, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, isMissingError, onInterval, parseCSON, parseJSON, parserFromExtension, partial, path, promisify, readFile, _ref;
 
 fs = require('fs');
 
@@ -66,12 +66,34 @@ isMissingError = function(error) {
   return error.cause && error.cause.code === 'ENOENT';
 };
 
+parseCSON = function(filename, content) {
+  var err;
+  try {
+    return CSON.parse(content);
+  } catch (_error) {
+    err = _error;
+    err.message += " in " + filename + ":" + (err.location.first_line + 1);
+    throw err;
+  }
+};
+
+parseJSON = function(filename, content) {
+  var err;
+  try {
+    return JSON.parse(content);
+  } catch (_error) {
+    err = _error;
+    err.message += " in " + filename;
+    throw err;
+  }
+};
+
 parserFromExtension = function(filename) {
   switch (path.extname(filename)) {
     case '.json':
-      return JSON.parse;
+      return partial(parseJSON, filename);
     case '.cson':
-      return CSON.parse;
+      return partial(parseCSON, filename);
     default:
       return identity;
   }

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -53,10 +53,24 @@ fileChanges = (filename, options) ->
 isMissingError = (error) ->
   error.cause && error.cause.code == 'ENOENT'
 
+parseCSON = (filename, content) ->
+  try
+    CSON.parse content
+  catch err
+    err.message += " in #{filename}:#{err.location.first_line + 1}"
+    throw err
+
+parseJSON = (filename, content) ->
+  try
+    JSON.parse content
+  catch err
+    err.message += " in #{filename}"
+    throw err
+
 parserFromExtension = (filename) ->
   switch path.extname filename
-    when '.json' then JSON.parse
-    when '.cson' then CSON.parse
+    when '.json' then partial(parseJSON, filename)
+    when '.cson' then partial(parseCSON, filename)
     else identity
 
 fileContent = (filename, options = {}) ->

--- a/test/file.test.coffee
+++ b/test/file.test.coffee
@@ -68,3 +68,29 @@ describe 'fileContent', ->
       it 'returns the updated content', ->
         @changed.then ({data}) =>
           assert.deepEqual @updated, data
+
+  describe 'a CSON file with syntax errors', ->
+    before ->
+      @filename = path.join os.tmpdir(), 'some-file.cson'
+      # The content is missing a closing quote after Hello
+      writeFile @filename, 'x: 10\nfoo: 13\nbar: "Hello\nzapp: 42\n'
+
+    it 'fails with a helpful error message', ->
+      checkError fileContent(@filename, watch: false), (error) =>
+        assert.equal 'SyntaxError', error.name
+        assert.equal """
+          missing " in #{@filename}:3
+        """, error.message
+
+  describe 'a JSON file with syntax errors', ->
+    before ->
+      @filename = path.join os.tmpdir(), 'some-file.json'
+      # The content is missing a comma after 42
+      writeFile @filename, '{\n  "foo": 42\n  "bar": 13\n}\n'
+
+    it 'fails with a helpful error message', ->
+      checkError fileContent(@filename, watch: false), (error) =>
+        assert.equal 'SyntaxError', error.name
+        assert.equal """
+          Unexpected string in #{@filename}
+        """, error.message


### PR DESCRIPTION
For CSON files it includes line numbers (since we get them for free), for JSON files just the name of the file.