### PR TITLE
fix: survive invalid json tmpfile on init()

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -146,6 +146,9 @@ tryCache = function(tmpDir) {
     if (error.code === 'ENOENT') {
       debug('No cache file found');
       return Observable.empty();
+    } else if (error instanceof SyntaxError) {
+      debug("Invalid cache file found: " + error.message);
+      return Observable.empty();
     } else {
       return Observable["throw"](error);
     }

--- a/src/cache.coffee
+++ b/src/cache.coffee
@@ -102,6 +102,9 @@ tryCache = (tmpDir) ->
       if error.code == 'ENOENT'
         debug 'No cache file found'
         Observable.empty()
+      else if error instanceof SyntaxError
+        debug "Invalid cache file found: #{error.message}"
+        Observable.empty()
       else
         Observable.throw error
 


### PR DESCRIPTION
Currently if you are missing a cache file during init() > meta >
activeLoader() > tryCache(), shared-store gracefully returns
Observable.empty() and gets on with life.  If the cache file happens to
be invalid, it dies, forcing you to restart your app to get a fresh
copy.  This change treats syntax errors the same as missing files (modulo a
debug line).