### PR TITLE
Safer interval handling

### DIFF
--- a/lib/interval.js
+++ b/lib/interval.js
@@ -40,7 +40,29 @@ onInterval = function(interval, load) {
     if (interval < 1000) {
       return Observable["throw"](new Error("Interval has to be at least 1s: " + interval + "ms"));
     } else {
-      return load().concat(Observable.interval(interval).flatMap(load));
+      return Observable.create(function(observer) {
+        var dispose, loadSubscription, prepareNext, runLoad, timeoutHandle;
+        loadSubscription = timeoutHandle = null;
+        dispose = function() {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+          if (loadSubscription) {
+            loadSubscription.dispose();
+          }
+          return loadSubscription = timeoutHandle = null;
+        };
+        prepareNext = function() {
+          dispose();
+          return timeoutHandle = setTimeout(runLoad, interval);
+        };
+        runLoad = function() {
+          dispose();
+          return loadSubscription = load().subscribe(observer.onNext.bind(observer), observer.onError.bind(observer), prepareNext);
+        };
+        runLoad();
+        return dispose;
+      });
     }
   } else {
     return load();

--- a/test/crash-recovery.test.coffee
+++ b/test/crash-recovery.test.coffee
@@ -57,6 +57,4 @@ describe 'Crash avoidance', ->
     env = _.extend { DEBUG: 'shared-store:cache' }, process.env
     execFile(childPath, [ @tmpDir ], { env })
       .then ([stdout, stderr]) ->
-        console.log stdout, stderr
-        assert.include 'Unexpected end of input', stderr
         assert.equal 'ok\n', stdout

--- a/test/file.test.coffee
+++ b/test/file.test.coffee
@@ -78,9 +78,8 @@ describe 'fileContent', ->
     it 'fails with a helpful error message', ->
       checkError fileContent(@filename, watch: false), (error) =>
         assert.equal 'SyntaxError', error.name
-        assert.equal """
-          missing " in #{@filename}:3
-        """, error.message
+        assert.include 'missing "', error.message
+        assert.include "in #{@filename}:3", error.message
 
   describe 'a JSON file with syntax errors', ->
     before ->
@@ -91,6 +90,5 @@ describe 'fileContent', ->
     it 'fails with a helpful error message', ->
       checkError fileContent(@filename, watch: false), (error) =>
         assert.equal 'SyntaxError', error.name
-        assert.equal """
-          Unexpected string in #{@filename}
-        """, error.message
+        assert.include 'Unexpected string', error.message
+        assert.include "in #{@filename}", error.message


### PR DESCRIPTION
Previously if `load()` took longer than `interval`, tasks started to pile up. This moves to the more reliable "only start counting once the last pass finished".