### PR TITLE
Consume body of 304 response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -65,6 +65,7 @@ httpResource = function(arg) {
     headers = response.headers, statusCode = response.statusCode;
     if (statusCode === 304) {
       debug('cache headers match');
+      response.resume();
     } else {
       debug('cache header mismatch');
       lastBody = wrap(body, url);

--- a/src/http.coffee
+++ b/src/http.coffee
@@ -52,6 +52,7 @@ httpResource = ({fetch, interval}) ->
     {headers, statusCode} = response
     if statusCode == 304
       debug 'cache headers match'
+      response.resume() # consume the (empty) body
     else
       debug 'cache header mismatch'
       lastBody = wrap body, url


### PR DESCRIPTION
Otherwise the `res#finish` event never fires, potentially causing socket timeouts (and also just leaving the socket open).