### PR TITLE
Gracefully handle missing dir

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -31,7 +31,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var Bluebird, CSON, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, isMissingError, onInterval, parseCSON, parseJSON, parserFromExtension, partial, path, promisify, readFile, ref;
+var Bluebird, CSON, debug, dirChanges, fileChanges, fileContent, fromPromiseFunction, fs, identity, isMissingError, onInterval, parseCSON, parseJSON, parserFromExtension, partial, path, promisify, readFile, ref, surroundingDirExists;
 
 fs = require('fs');
 
@@ -98,6 +98,20 @@ parserFromExtension = function(filename) {
   }
 };
 
+surroundingDirExists = function(filename) {
+  var dirStat, err;
+  try {
+    dirStat = fs.statSync(path.dirname(filename));
+    return dirStat.isDirectory();
+  } catch (error1) {
+    err = error1;
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+    return false;
+  }
+};
+
 fileContent = function(filename, options) {
   var defaultValue, hasDefault, interval, load, loaded, parse, returnDefault, rootDir, watch, wrap;
   if (options == null) {
@@ -133,7 +147,7 @@ fileContent = function(filename, options) {
     debug('readFile %s', filename);
     return readFile(filename, 'utf8').tap(loaded).then(parse).then(wrap)["catch"](isMissingError, returnDefault);
   });
-  if (watch) {
+  if (watch && surroundingDirExists(filename)) {
     return load().concat(fileChanges(filename).flatMap(load));
   } else {
     return onInterval(interval, load);

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -73,6 +73,14 @@ parserFromExtension = (filename) ->
     when '.cson' then partial(parseCSON, filename)
     else identity
 
+surroundingDirExists = (filename) ->
+  try
+    dirStat = fs.statSync path.dirname(filename)
+    return dirStat.isDirectory()
+  catch err
+    throw err if err.code != 'ENOENT'
+    false
+
 fileContent = (filename, options = {}) ->
   {defaultValue, watch, interval, parse, root: rootDir} = options
   filename = path.resolve rootDir, filename if rootDir?
@@ -98,7 +106,7 @@ fileContent = (filename, options = {}) ->
       .then wrap
       .catch isMissingError, returnDefault
 
-  if watch
+  if watch && surroundingDirExists(filename)
     load().concat fileChanges(filename).flatMap(load)
   else
     onInterval interval, load

--- a/test/file.test.coffee
+++ b/test/file.test.coffee
@@ -69,6 +69,17 @@ describe 'fileContent', ->
         @changed.then ({data}) =>
           assert.deepEqual @updated, data
 
+  describe 'when the surrounding dir does not exist', ->
+    before ->
+      @filename = path.join os.tmpdir(), 'not-a-dir', 'some-file.cson'
+
+    it 'does not fail, just ignores the watch', ->
+      fileContent(@filename, watch: true, defaultValue: 42)
+        .take(2)
+        .toPromise()
+        .then (result) ->
+          assert.equal 42, result
+
   describe 'a CSON file with syntax errors', ->
     before ->
       @filename = path.join os.tmpdir(), 'some-file.cson'


### PR DESCRIPTION
Only watch if the directory the file is in exists. Otherwise our current code just fails with an ugly `ENOENT`, even if the file itself was entirely optional.