### PR TITLE
feat: add fileAlternativesContent() handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ Support for the following extensions is built in:
   If `watch` is enabled, `interval` is automatically disabled.
   Defaults to `0` (disabled).
 
+### `fileAlternativesContent([filename, ...], options)`
+
+```js
+var fileAlternativesContent = require('shared-store/file-alternatives');
+```
+
+An observable representing the content of a single file, chosen from among
+multiple alternatives.  All of the alternatives in the array argument are
+checked for existence.  Iff exactly one exists, it is passed along with
+`options` to `fileContent()`.  This is useful for multiple extensions:
+
+```js
+fileAlternativesContent(['some-file.cson', 'some-file.json'], options)
+```
+
+or for a legacy path location and a new path location:
+
+```js
+fileAlternativesContent([oldestPath, oldPath, currentPath], options)
+```
+
+If more than one or none of the paths exist, it is an error.
 
 ### `httpResource({fetch, interval})`
 

--- a/file-alternatives.js
+++ b/file-alternatives.js
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2015, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+'use strict';
+module.exports = require('./lib/file-alternatives');

--- a/lib/file-alternatives.js
+++ b/lib/file-alternatives.js
@@ -1,0 +1,92 @@
+
+/*
+Copyright (c) 2015, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+'use strict';
+var Observable, _, debug, fileAlternativesContent, fileContent, filterExisting, fs, path;
+
+path = require('path');
+
+fs = require('fs');
+
+Observable = require('rx').Observable;
+
+_ = require('lodash');
+
+fileContent = require('./file');
+
+debug = require('debug')('shared-store:file-alternatives');
+
+filterExisting = function(filenames, rootDir) {
+  return filenames.filter(function(filename) {
+    if (rootDir != null) {
+      filename = path.resolve(rootDir, filename);
+    }
+    return !!(function() {
+      try {
+        return fs.statSync(filename);
+      } catch (error) {}
+    })();
+  });
+};
+
+fileAlternativesContent = function(filenames, options) {
+  var defaultValue, filename, hasDefault, hits, rootDir;
+  if (options == null) {
+    options = {};
+  }
+  defaultValue = options.defaultValue, rootDir = options.root;
+  if (!_.isArray(filenames)) {
+    filenames = [filenames];
+  }
+  debug('checking file alternatives', filenames);
+  hasDefault = defaultValue !== void 0;
+  hits = filterExisting(filenames, rootDir);
+  switch (hits.length) {
+    case 0:
+      debug('none found');
+      if (hasDefault) {
+        debug('using defaultValue');
+        return Observable.just(defaultValue);
+      } else {
+        return Observable["throw"](new Error("none of " + (filenames.join(', ')) + " exist"));
+      }
+      break;
+    case 1:
+      filename = hits[0];
+      debug('using %s', filename);
+      return fileContent(filename, options);
+    default:
+      return Observable["throw"](new Error("multiple file alternatives present: " + (hits.join(', '))));
+  }
+};
+
+module.exports = fileAlternativesContent;

--- a/src/file-alternatives.coffee
+++ b/src/file-alternatives.coffee
@@ -1,0 +1,77 @@
+###
+Copyright (c) 2015, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###
+
+'use strict'
+
+path = require 'path'
+fs = require 'fs'
+{ Observable } = require 'rx'
+_ = require 'lodash'
+
+fileContent = require './file'
+
+debug = require('debug') 'shared-store:file-alternatives'
+
+filterExisting = (filenames, rootDir) ->
+  filenames.filter (filename) ->
+    filename = path.resolve rootDir, filename if rootDir?
+    !! try fs.statSync filename
+
+fileAlternativesContent = (filenames, options = {}) ->
+  {defaultValue, root: rootDir} = options
+
+  filenames = [filenames] unless _.isArray filenames
+
+  debug 'checking file alternatives', filenames
+
+  hasDefault = defaultValue != undefined
+
+  hits = filterExisting(filenames, rootDir)
+
+  switch hits.length
+    when 0
+      debug 'none found'
+      if hasDefault
+        debug 'using defaultValue'
+        Observable.just defaultValue
+      else
+        Observable.throw new Error "none of #{filenames.join(', ')} exist"
+    when 1
+      filename = hits[0]
+      debug 'using %s', filename
+      fileContent filename, options
+    else
+      Observable.throw new Error(
+        "multiple file alternatives present: #{hits.join(', ')}"
+      )
+
+module.exports = fileAlternativesContent

--- a/test/file-alternatives.test.coffee
+++ b/test/file-alternatives.test.coffee
@@ -1,0 +1,60 @@
+'use strict'
+
+fs = require 'fs'
+path = require 'path'
+os = require 'os'
+
+assert = require 'assertive'
+Bluebird = require 'bluebird'
+
+fileAlternativesContent = require '../lib/file-alternatives'
+
+checkError = require './check-error'
+
+writeFile = Bluebird.promisify fs.writeFile
+
+describe 'fileAlternativesContent', ->
+  it 'is a function', ->
+    assert.hasType Function, fileAlternativesContent
+
+  describe 'for no existing files', ->
+    it 'fails with no defaultValue', ->
+      filename = path.join os.tmpdir(), 'missing.json'
+      checkError fileAlternativesContent([filename], watch: false), (error) ->
+        assert.include 'none of', error.message
+
+    it 'returns a defaultValue', ->
+      defaultValue = {}
+      fileAlternativesContent([], { watch: false, defaultValue })
+        .take(1).toPromise().then (data) -> assert.equal defaultValue, data
+
+  describe 'for a single existing file', ->
+    before ->
+      @filename = path.join os.tmpdir(), 'some-file.json'
+      @initialContent = initial: 'state'
+      writeFile @filename, JSON.stringify @initialContent
+
+    it 'accepts a string', ->
+      fileAlternativesContent(@filename, watch: false)
+        .take(1).toPromise().then ({data}) =>
+          assert.deepEqual @initialContent, data
+
+    it 'accepts an array with only one existing file', ->
+      bogus = path.join os.tmpdir(), 'missing.json'
+      fileAlternativesContent([bogus, @filename], watch: false)
+        .take(1).toPromise().then ({data}) =>
+          assert.deepEqual @initialContent, data
+
+  describe 'for multiple existing files', ->
+    before ->
+      @filename1 = path.join os.tmpdir(), 'some-file.json'
+      @filename2 = path.join os.tmpdir(), 'other-file.json'
+      @initialContent = initial: 'state'
+      Bluebird.map [@filename1, @filename2], (filename) =>
+        writeFile filename, JSON.stringify @initialContent
+
+    it 'dies horribly', ->
+      checkError(
+        fileAlternativesContent([@filename1, @filename2], watch: false),
+        (error) -> assert.include 'multiple', error.message
+      )


### PR DESCRIPTION
* works like (and falls back on) `fileContent()`
* accepts an array of files, exactly one of which must exist
* useful for multiple file extension options or legacy file locations