### PR TITLE
chore: Add warning for Syntax Error

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -123,6 +123,9 @@ SharedStore = (function(superClass) {
         };
         handleErr = function(err) {
           _this.removeListener('data', handleData);
+          if (err instanceof SyntaxError) {
+            console.warn("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nSyntax Error: " + err.message + "\nFalling back to cache.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+          }
           return latestCacheFile(_this._temp).subscribe(function(cache) {
             _this._handleUpdate(cache);
             return resolve(cache.data);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nlm": "^3.0.0",
     "nodemon": "^1.0.0",
     "rimraf": "^2.2.8",
-    "tmp": "0.0.24"
+    "tmp": "0.0.33"
   },
   "author": {
     "name": "Groupon",

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -90,6 +90,13 @@ class SharedStore extends EventEmitter
 
       handleErr = (err) =>
         @removeListener 'data', handleData
+        if err instanceof SyntaxError
+          console.warn """
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            Syntax Error: #{err.message}
+            Falling back to cache.
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            """
         latestCacheFile(@_temp).subscribe(
           (cache) =>
             @_handleUpdate cache

--- a/test/shared-store/file-store-with-cache
+++ b/test/shared-store/file-store-with-cache
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {promisify} = require('bluebird');
+const writeFile = promisify(fs.writeFile);
+
+const SharedStore = require('../../');
+const fileContent = require('../../lib/file');
+
+const filename = path.join(os.tmpdir(), 'some-file.cson');
+writeFile(filename, "cson with 'syntax error");
+
+const store = new SharedStore({
+  temp: process.argv[2],
+  loader: fileContent(filename, {watch: false}),
+});
+
+store.init(function(err, data) {
+  console.log('data: ' + data);
+  console.log('getCurrent: ' + store.getCurrent())
+  console.log('err: ' + err);
+  process.exit(0);
+});


### PR DESCRIPTION
Shared-store error handler tries to read data from cache and returns the data if cache read is successful. This may prevent users from noticing the error occurred while reading the required data and cache may provide stale data.
We could reject in the error handler to prevent the app from reading stale data. But that will prevent apps from starting. So we will log a prominent warning for an SyntaxError before we fallback to cache.