### PR TITLE
Allow skipping all tmp files

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -154,11 +154,18 @@ tryCache = function(tmpDir) {
   });
 };
 
-activeLoader = function(meta, loader, tmpDir) {
+activeLoader = function(meta, loader, tmpDir, writeCacheFiles) {
   var data, fromCache, onDataLoaded, rawData, ref1, tearDownCrashHandler;
   rawData = meta.flatMapLatest(loader).map(function(otherData) {
     otherData.usingCache = false;
     return otherData;
+  });
+  if (!writeCacheFiles) {
+    debug('skip writing a cache, returning raw data stream');
+    return rawData.distinctUntilChanged(property('data'), isEqual).publish();
+  }
+  debug('wrapping data stream in cache', {
+    tmpDir: tmpDir
   });
   ref1 = crashRecovery(tmpDir), onDataLoaded = ref1.onDataLoaded, tearDownCrashHandler = ref1.tearDownCrashHandler;
   data = rawData.tap(onDataLoaded, tearDownCrashHandler, tearDownCrashHandler);
@@ -170,9 +177,12 @@ passiveLoader = function(tmpDir) {
   return latestCacheFile(tmpDir, true).publish();
 };
 
-this.cachedLoader = function(meta, loader, tmpDir, active) {
+this.cachedLoader = function(meta, loader, tmpDir, active, writeCacheFiles) {
+  if (writeCacheFiles == null) {
+    writeCacheFiles = true;
+  }
   debug('cachedLoader(%j)', active);
-  loader = active ? activeLoader(meta, loader, tmpDir) : passiveLoader(tmpDir);
+  loader = active ? activeLoader(meta, loader, tmpDir, writeCacheFiles) : passiveLoader(tmpDir);
   return Observable.create(function(observer) {
     loader.subscribe(observer);
     loader.connect();

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -92,18 +92,25 @@ SharedStore = (function(superClass) {
           ref1.dispose();
         }
         meta = _this._createMeta();
-        _this.stream = cachedLoader(meta, loader, _this._temp, _this._active);
+        _this.stream = cachedLoader(meta, loader, _this._temp, _this._active, _this._writeCacheFiles);
         return _this.subscription = _this.stream.subscribe(_this._handleUpdate, _this._handleError);
       };
     })(this);
     this._createStream();
     this.on('meta', this._handleMetaUpdate);
     this._cache = null;
+    this._writeCacheFiles = !!this._active;
     this._retryTimeout = TEN_SECONDS;
   }
 
-  SharedStore.prototype.setActive = function(_active) {
-    this._active = _active != null ? _active : true;
+  SharedStore.prototype.setActive = function(isActive) {
+    if (isActive == null) {
+      isActive = true;
+    }
+    this._active = !!isActive;
+    if (isActive && typeof isActive.writeCacheFiles === 'boolean') {
+      this._writeCacheFiles = isActive.writeCacheFiles;
+    }
     return this._createStream();
   };
 

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -67,15 +67,19 @@ class SharedStore extends EventEmitter
     @_createStream = =>
       @subscription?.dispose()
       meta = @_createMeta()
-      @stream = cachedLoader meta, loader, @_temp, @_active
+      @stream = cachedLoader meta, loader, @_temp, @_active, @_writeCacheFiles
       @subscription = @stream.subscribe @_handleUpdate, @_handleError
     @_createStream()
 
     @on 'meta', @_handleMetaUpdate
     @_cache = null
+    @_writeCacheFiles = !!@_active
     @_retryTimeout = TEN_SECONDS
 
-  setActive: (@_active=true) ->
+  setActive: (isActive = true) ->
+    @_active = !!isActive
+    if isActive && typeof isActive.writeCacheFiles == 'boolean'
+      @_writeCacheFiles = isActive.writeCacheFiles
     @_createStream()
 
   getCurrent: ->

--- a/test/shared-store/no-cache.test.coffee
+++ b/test/shared-store/no-cache.test.coffee
@@ -1,0 +1,50 @@
+'use strict'
+
+path = require 'path'
+os = require 'os'
+fs = require 'fs'
+
+assert = require 'assertive'
+{Observable} = require 'rx'
+tmp = require 'tmp'
+
+SharedStore = require '../../'
+
+BASE_CONFIG = opt: 'value'
+
+describe 'With cache disabled', ->
+  before (done) ->
+    tmp.dir { unsafeCleanup: true }, (err, @tmpDir) => done(err)
+    return
+
+  describe 'with cache disabled', ->
+    before (done) ->
+      @overrideFile =
+        path.join os.tmpdir(), 'shared-store.test.json'
+      @initialOverrides = override: 'loaded'
+
+      fs.writeFile(
+        @overrideFile, JSON.stringify(@initialOverrides), done
+      )
+      return
+
+    before (done) ->
+      @store = new SharedStore {
+        temp: @tmpDir
+        active: true
+        loader: (baseConfig) =>
+          assert.deepEqual BASE_CONFIG, baseConfig
+          Observable.just(data: { static: 'data' }, source: 'static')
+      }
+      @store.setActive writeCacheFiles: false
+      @store.init opt: 'value', (err, @initCallbackData) => done(err)
+      return
+
+    it 'returns the initial data', ->
+      assert.deepEqual {
+        static: 'data'
+      }, @store.getCurrent()
+
+    it 'writes no cache file', ->
+      cacheFiles = fs.readdirSync @tmpDir
+      assert.equal 0, cacheFiles.length


### PR DESCRIPTION
We've been running into cases where we switched to local and reliable sources (optionally) and having the cache is causing more issues than it solves.