### PR TITLE
default `setActive()` to write cache files

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -105,7 +105,9 @@ SharedStore = (function(superClass) {
 
   SharedStore.prototype.setActive = function(isActive) {
     if (isActive == null) {
-      isActive = true;
+      isActive = {
+        writeCacheFiles: true
+      };
     }
     this._active = !!isActive;
     if (isActive && typeof isActive.writeCacheFiles === 'boolean') {

--- a/src/shared-store.coffee
+++ b/src/shared-store.coffee
@@ -76,7 +76,7 @@ class SharedStore extends EventEmitter
     @_writeCacheFiles = !!@_active
     @_retryTimeout = TEN_SECONDS
 
-  setActive: (isActive = true) ->
+  setActive: (isActive = { writeCacheFiles: true }) ->
     @_active = !!isActive
     if isActive && typeof isActive.writeCacheFiles == 'boolean'
       @_writeCacheFiles = isActive.writeCacheFiles


### PR DESCRIPTION
Given legacy code which called `setActive()` with no arguments, we
should also default to the old behavior of active mode writing out cache
files.

The broken case is when the shared store was instantiated not active,
then `.setActive()` was called later with no arguments