### PR TITLE
fix: set internal vars ahead of time

### DIFF
--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -72,6 +72,9 @@ class SharedStore extends EventEmitter {
     this._handleMetaUpdate = this._handleMetaUpdate.bind(this);
     this._retry = this._retry.bind(this);
     this._active = active != null ? active : cluster.isMaster;
+    this._cache = null;
+    this._writeCacheFiles = !!this._active;
+    this._retryTimeout = TEN_SECONDS;
     this._temp = path.resolve(temp);
 
     if (this._temp === '/') {
@@ -82,9 +85,6 @@ class SharedStore extends EventEmitter {
     this._createStream();
 
     this.on('meta', this._handleMetaUpdate);
-    this._cache = null;
-    this._writeCacheFiles = !!this._active;
-    this._retryTimeout = TEN_SECONDS;
   }
 
   setActive(


### PR DESCRIPTION
- [x] fix: set internal properties before `_createStream()` is called