### PR TITLE
refactor: switch to rx-lite packages

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -42,7 +42,7 @@ const isEqual = require('lodash.isequal');
 
 const mkdirp = require('mkdirp');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite-aggregates');
 
 const { promisify } = require('util');
 

--- a/lib/dir-content.js
+++ b/lib/dir-content.js
@@ -38,7 +38,7 @@ const path = require('path');
 
 const debug = require('debug')('shared-store:dir-content');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const { promisify } = require('util');
 

--- a/lib/file-alternatives.js
+++ b/lib/file-alternatives.js
@@ -38,7 +38,7 @@ const path = require('path');
 
 const debug = require('debug')('shared-store:file-alternatives');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const fileContent = require('./file');
 

--- a/lib/interval.js
+++ b/lib/interval.js
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 'use strict';
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 function onInterval(interval, load) {
   if (interval > 0) {

--- a/lib/latest-file.js
+++ b/lib/latest-file.js
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 'use strict';
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite-extras');
 
 const { dirChanges, dirContent } = require('./dir-content');
 

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 'use strict';
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 function unexpectedError(err) {
   return process.nextTick(() => {

--- a/lib/shared-store.js
+++ b/lib/shared-store.js
@@ -40,7 +40,7 @@ const path = require('path');
 
 const freeze = require('deep-freeze');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const { cachedLoader, latestCacheFile } = require('./cache');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,36 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/rx-core": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
+      "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA="
+    },
+    "@types/rx-core-binding": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
+      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+      "requires": {
+        "@types/rx-core": "*"
+      }
+    },
+    "@types/rx-lite": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.6.tgz",
+      "integrity": "sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==",
+      "requires": {
+        "@types/rx-core": "*",
+        "@types/rx-core-binding": "*"
+      }
+    },
+    "@types/rx-lite-aggregates": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
+      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+      "requires": {
+        "@types/rx-lite": "*"
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -460,9 +490,9 @@
       "dev": true
     },
     "assertive": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/assertive/-/assertive-5.0.0.tgz",
-      "integrity": "sha512-nOPE/h5+vnp3Qz2LfZEmIAzYavNO3b3lxRvTH6cPuAYHt4ZvFkUQV58Uoyt3uhAM0y4aO7kn2pR7K1c4Q/lLdw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/assertive/-/assertive-5.0.1.tgz",
+      "integrity": "sha512-Z3z1o83sTV1xs2NH7Mdr8TQm846z10MVlExZ4Oytwhmb7ZWAU4gvtEAvQucIaeRGT8/b0k7eOiYHpGV7UMPJnA==",
       "dev": true,
       "requires": {
         "lodash.isequal": "^4.5.0"
@@ -3241,10 +3271,26 @@
         "is-promise": "^2.1.0"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "rx-lite-extras": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-extras/-/rx-lite-extras-4.0.8.tgz",
+      "integrity": "sha1-fkg2PaKk88xPLWZ1AidT9stWJzE=",
+      "requires": {
+        "rx-lite": "*"
+      }
     },
     "rxjs": {
       "version": "6.5.5",

--- a/package.json
+++ b/package.json
@@ -33,16 +33,20 @@
     }
   },
   "dependencies": {
+    "@types/rx-lite": "^4.0.6",
+    "@types/rx-lite-aggregates": "^4.0.3",
     "cson-parser": "^4.0.4",
     "debug": "^4.1.1",
     "deep-freeze": "0.0.1",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "mkdirp": "^1.0.4",
-    "rx": "^4.1.0"
+    "rx-lite": "^4.0.8",
+    "rx-lite-aggregates": "^4.0.8",
+    "rx-lite-extras": "^4.0.8"
   },
   "devDependencies": {
-    "assertive": "^5.0.0",
+    "assertive": "^5.0.1",
     "eslint": "^6.8.0",
     "eslint-config-groupon": "^9.0.0",
     "eslint-plugin-import": "^2.20.1",

--- a/test/check-error.js
+++ b/test/check-error.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 function checkError(observable, fn) {
   const OK = {};

--- a/test/interval.test.js
+++ b/test/interval.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const onInterval = require('../lib/interval');
 

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const { fromPromiseFunction } = require('../lib/promise');
 

--- a/test/shared-store/error-handling.test.js
+++ b/test/shared-store/error-handling.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const tmp = require('tmp');
 

--- a/test/shared-store/index.test.js
+++ b/test/shared-store/index.test.js
@@ -8,7 +8,7 @@ const path = require('path');
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const tmp = require('tmp');
 

--- a/test/shared-store/no-cache.test.js
+++ b/test/shared-store/no-cache.test.js
@@ -8,7 +8,7 @@ const path = require('path');
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const tmp = require('tmp');
 

--- a/test/shared-store/retry.test.js
+++ b/test/shared-store/retry.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const tmp = require('tmp');
 

--- a/test/shared-store/with-cache.test.js
+++ b/test/shared-store/with-cache.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assertive');
 
-const { Observable } = require('rx');
+const { Observable } = require('rx-lite');
 
 const tmp = require('tmp');
 


### PR DESCRIPTION
cost-of-modules summary:

**before** with `rx`:
| name | children | size |
| ---- | --- | --- |
| rx | 0 | 6.29M |
|  ... | | |
|  | | |
| 7 modules | 2 children | 6.91M  |

**after** with `rx-lite` packages:
| name | children | size |
| ---- | --- | --- |
| rx-lite-aggregates | 1 | 0.53M |
| rx-lite-extras | 1 | 0.49M |
| rx-lite | 0 | 0.44M |
|  ... | | |
|  | | |
| 11 modules | 4 children | 1.73M  |